### PR TITLE
Import Resources Rake Tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'shoulda-matchers'
   gem 'activesupport'
-  
+  gem 'colorize'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     coderay (1.1.2)
+    colorize (0.8.1)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -182,6 +183,7 @@ DEPENDENCIES
   activesupport
   byebug
   capybara
+  colorize
   factory_bot_rails
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/lib/tasks/import/customers.rake
+++ b/lib/tasks/import/customers.rake
@@ -10,9 +10,9 @@ namespace :import do
       index += 1
       print "#{index}/#{customer_count} ".light_blue
       if Customer.create(customer.to_h)
-        puts "#{customer[:first_name] + " " + customer[:last_name]}".green
+        puts "#{customer["first_name"] + " " + customer["last_name"]}".green
       else
-        puts "#{customer[:first_name] + " " + customer[:last_name]} was unable to be saved".red
+        puts "#{customer["first_name"] + " " + customer["last_name"]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/customers.rake
+++ b/lib/tasks/import/customers.rake
@@ -5,13 +5,14 @@ namespace :import do
   task customers: :environment do
     file = CSV.table("./db/csv/customers.csv", options = Hash.new)
     customer_count = file.count
-    index = 1
+    index = 0
     file.each do |customer|
-      p "#{index}/#{customer_count}"
-      if Customer.create(customer)
-        puts "#{customer.first_name + " " + customer.last_name}".green
+      index += 1
+      print "#{index}/#{customer_count} ".light_blue
+      if Customer.create(customer.to_h)
+        puts "#{customer[:first_name] + " " + customer[:last_name]}".green
       else
-        puts "#{customer.first_name + " " + customer.last_name} was unable to be saved".red
+        puts "#{customer[:first_name] + " " + customer[:last_name]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/customers.rake
+++ b/lib/tasks/import/customers.rake
@@ -3,10 +3,9 @@ require 'csv'
 namespace :import do
   desc "Imports Customer records from CSV in db/csv"
   task customers: :environment do
-    file = CSV.table("./db/csv/customers.csv", options = Hash.new)
     customer_count = file.count
     index = 0
-    file.each do |customer|
+    CSV.foreach("./db/csv/customers.csv", headers: true) do |customer|
       index += 1
       print "#{index}/#{customer_count} ".light_blue
       if Customer.create(customer.to_h)

--- a/lib/tasks/import/customers.rake
+++ b/lib/tasks/import/customers.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :import do
+  desc "Imports Customer records from CSV in db/csv"
+  task customers: :environment do
+    file = CSV.table("./db/csv/customers.csv", options = Hash.new)
+    customer_count = file.count
+    index = 1
+    file.each do |customer|
+      p "#{index}/#{customer_count}"
+      if Customer.create(customer)
+        puts "#{customer.name}".green
+      else
+        puts "#{customer.name} was unable to be saved".red
+      end
+    end
+  end
+end

--- a/lib/tasks/import/customers.rake
+++ b/lib/tasks/import/customers.rake
@@ -3,7 +3,8 @@ require 'csv'
 namespace :import do
   desc "Imports Customer records from CSV in db/csv"
   task customers: :environment do
-    customer_count = file.count
+    customer_count = 0
+    CSV.foreach("./db/csv/customers.csv", headers: true) {|row| customer_count += 1 }
     index = 0
     CSV.foreach("./db/csv/customers.csv", headers: true) do |customer|
       index += 1

--- a/lib/tasks/import/customers.rake
+++ b/lib/tasks/import/customers.rake
@@ -9,9 +9,9 @@ namespace :import do
     file.each do |customer|
       p "#{index}/#{customer_count}"
       if Customer.create(customer)
-        puts "#{customer.name}".green
+        puts "#{customer.first_name + " " + customer.last_name}".green
       else
-        puts "#{customer.name} was unable to be saved".red
+        puts "#{customer.first_name + " " + customer.last_name} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/invoice_items.rake
+++ b/lib/tasks/import/invoice_items.rake
@@ -3,10 +3,9 @@ require 'csv'
 namespace :import do
   desc "Imports InvoiceItems records from CSV in db/csv"
   task invoice_items: :environment do
-    file = CSV.table("./db/csv/invoice_items.csv", options = Hash.new)
     invoice_item_count = file.count
     index = 0
-    file.each do |invoice_item|
+    CSV.foreach("./db/csv/invoice_items.csv", headers: true) do |invoice_item|
       index += 1
       print "#{index}/#{invoice_item_count} ".light_blue
       if InvoiceItem.create(invoice_item.to_h)

--- a/lib/tasks/import/invoice_items.rake
+++ b/lib/tasks/import/invoice_items.rake
@@ -10,9 +10,9 @@ namespace :import do
       index += 1
       print "#{index}/#{invoice_item_count} ".light_blue
       if InvoiceItem.create(invoice_item.to_h)
-        puts "Invoice Item #{invoice_item[:id]}".green
+        puts "Invoice Item #{invoice_item["id"]}".green
       else
-        puts "Invoice Item #{invoice_item[:id]} was unable to be saved".red
+        puts "Invoice Item #{invoice_item["id"]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/invoice_items.rake
+++ b/lib/tasks/import/invoice_items.rake
@@ -3,7 +3,8 @@ require 'csv'
 namespace :import do
   desc "Imports InvoiceItems records from CSV in db/csv"
   task invoice_items: :environment do
-    invoice_item_count = file.count
+    invoice_item_count = 0
+    CSV.foreach("./db/csv/invoice_items.csv", headers: true) {|row| invoice_item_count += 1 }
     index = 0
     CSV.foreach("./db/csv/invoice_items.csv", headers: true) do |invoice_item|
       index += 1

--- a/lib/tasks/import/invoice_items.rake
+++ b/lib/tasks/import/invoice_items.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :import do
+  desc "Imports InvoiceItems records from CSV in db/csv"
+  task invoice_items: :environment do
+    file = CSV.table("./db/csv/invoice_items.csv", options = Hash.new)
+    invoice_item_count = file.count
+    index = 1
+    file.each do |invoice_item|
+      p "#{index}/#{invoice_item_count}"
+      if InvoiceItems.create(invoice_item)
+        puts "Invoice Item #{invoice_item.id}".green
+      else
+        puts "Invoice Item #{invoice_item.id} was unable to be saved".red
+      end
+    end
+  end
+end

--- a/lib/tasks/import/invoice_items.rake
+++ b/lib/tasks/import/invoice_items.rake
@@ -9,7 +9,7 @@ namespace :import do
     file.each do |invoice_item|
       index += 1
       print "#{index}/#{invoice_item_count} ".light_blue
-      if InvoiceItems.create(invoice_item.to_h)
+      if InvoiceItem.create(invoice_item.to_h)
         puts "Invoice Item #{invoice_item[:id]}".green
       else
         puts "Invoice Item #{invoice_item[:id]} was unable to be saved".red

--- a/lib/tasks/import/invoice_items.rake
+++ b/lib/tasks/import/invoice_items.rake
@@ -5,13 +5,14 @@ namespace :import do
   task invoice_items: :environment do
     file = CSV.table("./db/csv/invoice_items.csv", options = Hash.new)
     invoice_item_count = file.count
-    index = 1
+    index = 0
     file.each do |invoice_item|
-      p "#{index}/#{invoice_item_count}"
-      if InvoiceItems.create(invoice_item)
-        puts "Invoice Item #{invoice_item.id}".green
+      index += 1
+      print "#{index}/#{invoice_item_count} ".light_blue
+      if InvoiceItems.create(invoice_item.to_h)
+        puts "Invoice Item #{invoice_item[:id]}".green
       else
-        puts "Invoice Item #{invoice_item.id} was unable to be saved".red
+        puts "Invoice Item #{invoice_item[:id]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/invoices.rake
+++ b/lib/tasks/import/invoices.rake
@@ -10,9 +10,9 @@ namespace :import do
       index += 1
       print "#{index}/#{invoice_count} ".light_code
       if Invoice.create(invoice.to_h)
-        puts "Invoice #{invoice[:id]}".green
+        puts "Invoice #{invoice["id"]}".green
       else
-        puts "Invoice #{invoice[:id]} was unable to be saved".red
+        puts "Invoice #{invoice["id"]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/invoices.rake
+++ b/lib/tasks/import/invoices.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :import do
+  desc "Imports Invoices records from CSV in db/csv"
+  task invoices: :environment do
+    file = CSV.table("./db/csv/invoices.csv", options = Hash.new)
+    invoice_count = file.count
+    index = 1
+    file.each do |invoice|
+      p "#{index}/#{invoice_count}"
+      if Invoices.create(invoice)
+        puts "Invoice #{invoice.id}".green
+      else
+        puts "Invoice #{invoice.id} was unable to be saved".red
+      end
+    end
+  end
+end

--- a/lib/tasks/import/invoices.rake
+++ b/lib/tasks/import/invoices.rake
@@ -3,10 +3,9 @@ require 'csv'
 namespace :import do
   desc "Imports Invoices records from CSV in db/csv"
   task invoices: :environment do
-    file = CSV.table("./db/csv/invoices.csv", options = Hash.new)
     invoice_count = file.count
     index = 0
-    file.each do |invoice|
+    CSV.foreach("./db/csv/invoices.csv", headers: true) do |invoice|
       index += 1
       print "#{index}/#{invoice_count} ".light_code
       if Invoice.create(invoice.to_h)

--- a/lib/tasks/import/invoices.rake
+++ b/lib/tasks/import/invoices.rake
@@ -5,13 +5,14 @@ namespace :import do
   task invoices: :environment do
     file = CSV.table("./db/csv/invoices.csv", options = Hash.new)
     invoice_count = file.count
-    index = 1
+    index = 0
     file.each do |invoice|
-      p "#{index}/#{invoice_count}"
-      if Invoices.create(invoice)
-        puts "Invoice #{invoice.id}".green
+      index += 1
+      print "#{index}/#{invoice_count} ".light_code
+      if Invoice.create(invoice.to_h)
+        puts "Invoice #{invoice[:id]}".green
       else
-        puts "Invoice #{invoice.id} was unable to be saved".red
+        puts "Invoice #{invoice[:id]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/invoices.rake
+++ b/lib/tasks/import/invoices.rake
@@ -3,7 +3,8 @@ require 'csv'
 namespace :import do
   desc "Imports Invoices records from CSV in db/csv"
   task invoices: :environment do
-    invoice_count = file.count
+    invoice_count = 0
+    CSV.foreach("./db/csv/invoices.csv", headers: true) {|row| invoice_count += 1 }
     index = 0
     CSV.foreach("./db/csv/invoices.csv", headers: true) do |invoice|
       index += 1

--- a/lib/tasks/import/items.rake
+++ b/lib/tasks/import/items.rake
@@ -5,13 +5,14 @@ namespace :import do
   task items: :environment do
     file = CSV.table("./db/csv/items.csv", options = Hash.new)
     item_count = file.count
-    index = 1
+    index = 0
     file.each do |item|
-      p "#{index}/#{item_count}"
-      if Items.create(item)
-        puts "#{item.name}".green
+      index += 1
+      print "#{index}/#{item_count} ".light_blue
+      if Item.create(item.to_h)
+        puts "#{item[:name]}".green
       else
-        puts "#{item.name} was unable to be saved".red
+        puts "#{item[:name]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/items.rake
+++ b/lib/tasks/import/items.rake
@@ -3,7 +3,8 @@ require 'csv'
 namespace :import do
   desc "Imports Items records from CSV in db/csv"
   task items: :environment do
-    item_count = file.count
+    item_count = 0
+    CSV.foreach("./db/csv/items.csv", headers: true) {|row| item_count += 1 }
     index = 0
     CSV.foreach("./db/csv/items.csv", headers: true) do |item|
       index += 1

--- a/lib/tasks/import/items.rake
+++ b/lib/tasks/import/items.rake
@@ -7,9 +7,8 @@ namespace :import do
     item_count = file.count
     index = 1
     file.each do |item|
-      merchant = Merchant.find(item.merchant_id)
       p "#{index}/#{item_count}"
-      if merchant.items.create(item)
+      if Items.create(item)
         puts "#{item.name}".green
       else
         puts "#{item.name} was unable to be saved".red

--- a/lib/tasks/import/items.rake
+++ b/lib/tasks/import/items.rake
@@ -3,10 +3,9 @@ require 'csv'
 namespace :import do
   desc "Imports Items records from CSV in db/csv"
   task items: :environment do
-    file = CSV.table("./db/csv/items.csv", options = Hash.new)
     item_count = file.count
     index = 0
-    file.each do |item|
+    CSV.foreach("./db/csv/items.csv", headers: true) do |item|
       index += 1
       print "#{index}/#{item_count} ".light_blue
       if Item.create(item.to_h)

--- a/lib/tasks/import/items.rake
+++ b/lib/tasks/import/items.rake
@@ -10,9 +10,9 @@ namespace :import do
       index += 1
       print "#{index}/#{item_count} ".light_blue
       if Item.create(item.to_h)
-        puts "#{item[:name]}".green
+        puts "#{item["name"]}".green
       else
-        puts "#{item[:name]} was unable to be saved".red
+        puts "#{item["name"]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/items.rake
+++ b/lib/tasks/import/items.rake
@@ -1,0 +1,19 @@
+require 'csv'
+
+namespace :import do
+  desc "Imports Items records from CSV in db/csv"
+  task items: :environment do
+    file = CSV.table("./db/csv/items.csv", options = Hash.new)
+    item_count = file.count
+    index = 1
+    file.each do |item|
+      merchant = Merchant.find(item.merchant_id)
+      p "#{index}/#{item_count}"
+      if merchant.items.create(item)
+        puts "#{item.name}".green
+      else
+        puts "#{item.name} was unable to be saved".red
+      end
+    end
+  end
+end

--- a/lib/tasks/import/merchants.rake
+++ b/lib/tasks/import/merchants.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :import do
+  desc "Imports Merchant records from CSV in db/csv"
+  task merchants: :environment do
+    file = CSV.table("./db/csv/merchants.csv", options = Hash.new)
+    merchant_count = file.count
+    index = 1
+    file.each do |merchant|
+      p "#{index}/#{merchant_count}"
+      if Merchant.create(merchant)
+        puts "#{merchant.name}".green
+      else
+        puts "#{merchant.name} was unable to be saved".red
+      end
+    end
+  end
+end

--- a/lib/tasks/import/merchants.rake
+++ b/lib/tasks/import/merchants.rake
@@ -5,13 +5,14 @@ namespace :import do
   task merchants: :environment do
     file = CSV.table("./db/csv/merchants.csv", options = Hash.new)
     merchant_count = file.count
-    index = 1
+    index = 0
     file.each do |merchant|
-      p "#{index}/#{merchant_count}"
-      if Merchant.create(merchant)
-        puts "#{merchant.name}".green
+      index += 1
+      print "#{index}/#{merchant_count} ".light_blue
+      if Merchant.create(merchant.to_h)
+        puts "#{merchant[:name]}".green
       else
-        puts "#{merchant.name} was unable to be saved".red
+        puts "#{merchant[:name]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/merchants.rake
+++ b/lib/tasks/import/merchants.rake
@@ -3,10 +3,9 @@ require 'csv'
 namespace :import do
   desc "Imports Merchant records from CSV in db/csv"
   task merchants: :environment do
-    file = CSV.table("./db/csv/merchants.csv", options = Hash.new)
     merchant_count = file.count
     index = 0
-    file.each do |merchant|
+    CSV.foreach("./db/csv/merchants.csv", headers: true) do |merchant|
       index += 1
       print "#{index}/#{merchant_count} ".light_blue
       if Merchant.create(merchant.to_h)

--- a/lib/tasks/import/merchants.rake
+++ b/lib/tasks/import/merchants.rake
@@ -10,9 +10,9 @@ namespace :import do
       index += 1
       print "#{index}/#{merchant_count} ".light_blue
       if Merchant.create(merchant.to_h)
-        puts "#{merchant[:name]}".green
+        puts "#{merchant["name"]}".green
       else
-        puts "#{merchant[:name]} was unable to be saved".red
+        puts "#{merchant["name"]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/merchants.rake
+++ b/lib/tasks/import/merchants.rake
@@ -3,9 +3,10 @@ require 'csv'
 namespace :import do
   desc "Imports Merchant records from CSV in db/csv"
   task merchants: :environment do
-    merchant_count = file.count
+    merchant_count = 0
+    CSV.foreach("./db/csv/merchants.csv", headers: true) {|row| merchant_count += 1 }
     index = 0
-    CSV.foreach("./db/csv/merchants.csv", headers: true) do |merchant|
+    CSV.foreach("./db/csv/merchants.csv", :headers => true) do |merchant|
       index += 1
       print "#{index}/#{merchant_count} ".light_blue
       if Merchant.create(merchant.to_h)

--- a/lib/tasks/import/transactions.rake
+++ b/lib/tasks/import/transactions.rake
@@ -10,9 +10,9 @@ namespace :import do
       index += 1
       print "#{index}/#{transaction_count} ".light_blue
       if Transaction.create(transaction.to_h)
-        puts "Transaction #{transaction[:id]}".green
+        puts "Transaction #{transaction["id"]}".green
       else
-        puts "Transaction #{transaction[:id]} was unable to be saved".red
+        puts "Transaction #{transaction["id"]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/transactions.rake
+++ b/lib/tasks/import/transactions.rake
@@ -3,10 +3,9 @@ require 'csv'
 namespace :import do
   desc "Imports Transactions records from CSV in db/csv"
   task transactions: :environment do
-    file = CSV.table("./db/csv/transactions.csv", options = Hash.new)
     transaction_count = file.count
     index = 0
-    file.each do |transaction|
+    CSV.foreach("./db/csv/transactions.csv", headers: true) do |transaction|
       index += 1
       print "#{index}/#{transaction_count} ".light_blue
       if Transaction.create(transaction.to_h)

--- a/lib/tasks/import/transactions.rake
+++ b/lib/tasks/import/transactions.rake
@@ -5,13 +5,14 @@ namespace :import do
   task transactions: :environment do
     file = CSV.table("./db/csv/transactions.csv", options = Hash.new)
     transaction_count = file.count
-    index = 1
+    index = 0
     file.each do |transaction|
-      p "#{index}/#{transaction_count}"
-      if Transactions.create(transaction)
-        puts "Transaction #{transaction.id}".green
+      index += 1
+      print "#{index}/#{transaction_count} ".light_blue
+      if Transactions.create(transaction.to_h)
+        puts "Transaction #{transaction[:id]}".green
       else
-        puts "Transaction #{transaction.id} was unable to be saved".red
+        puts "Transaction #{transaction[:id]} was unable to be saved".red
       end
     end
   end

--- a/lib/tasks/import/transactions.rake
+++ b/lib/tasks/import/transactions.rake
@@ -9,7 +9,7 @@ namespace :import do
     file.each do |transaction|
       index += 1
       print "#{index}/#{transaction_count} ".light_blue
-      if Transactions.create(transaction.to_h)
+      if Transaction.create(transaction.to_h)
         puts "Transaction #{transaction[:id]}".green
       else
         puts "Transaction #{transaction[:id]} was unable to be saved".red

--- a/lib/tasks/import/transactions.rake
+++ b/lib/tasks/import/transactions.rake
@@ -3,7 +3,8 @@ require 'csv'
 namespace :import do
   desc "Imports Transactions records from CSV in db/csv"
   task transactions: :environment do
-    transaction_count = file.count
+    transaction_count = 0
+    CSV.foreach("./db/csv/transactions.csv", headers: true) {|row| transaction_count += 1 }
     index = 0
     CSV.foreach("./db/csv/transactions.csv", headers: true) do |transaction|
       index += 1

--- a/lib/tasks/import/transactions.rake
+++ b/lib/tasks/import/transactions.rake
@@ -1,0 +1,18 @@
+require 'csv'
+
+namespace :import do
+  desc "Imports Transactions records from CSV in db/csv"
+  task transactions: :environment do
+    file = CSV.table("./db/csv/transactions.csv", options = Hash.new)
+    transaction_count = file.count
+    index = 1
+    file.each do |transaction|
+      p "#{index}/#{transaction_count}"
+      if Transactions.create(transaction)
+        puts "Transaction #{transaction.id}".green
+      else
+        puts "Transaction #{transaction.id} was unable to be saved".red
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR brings in the functionality to import resources to our database using Rake tasks using CSV files. These Rake tasks assume that you have placed the required files in the `db/csv` folder, and are following the naming convention of a `pluralized_resource_name.csv`.

These have a lot of repetition and could probably be put into a Class at a later time. 