### PR TITLE
Show Endpoints

### DIFF
--- a/app/controllers/api/v1/customers_controller.rb
+++ b/app/controllers/api/v1/customers_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::CustomersController < ApplicationController
   def index
     render json: CustomerSerializer.new(Customer.all)
   end
+
+  def show
+    render json: CustomerSerializer.new(Customer.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/invoice_items_controller.rb
+++ b/app/controllers/api/v1/invoice_items_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::InvoiceItemsController < ApplicationController
   def index
     render json: InvoiceItemSerializer.new(InvoiceItem.all)
   end
+
+  def show
+    render json: InvoiceItemSerializer.new(InvoiceItem.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::InvoicesController < ApplicationController
   def index
     render json: InvoiceSerializer.new(Invoice.all)
   end
+
+  def show
+    render json: InvoiceSerializer.new(Invoice.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::ItemsController < ApplicationController
   def index
     render json: ItemSerializer.new(Item.all)
   end
+
+  def show
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::MerchantsController < ApplicationController
   def index
     render json: MerchantSerializer.new(Merchant.all)
   end
+
+  def show
+    render json: MerchantSerializer.new(Merchant.find(params[:id]))
+  end
 end

--- a/app/controllers/api/v1/transactions_controller.rb
+++ b/app/controllers/api/v1/transactions_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::TransactionsController < ApplicationController
   def index
     render json: TransactionSerializer.new(Transaction.all)
   end
+
+  def show
+    render json: TransactionSerializer.new(Transaction.find(params[:id]))
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :merchants, only: [:index]
-      resources :customers, only: [:index]
-      resources :items, only: [:index]
-      resources :invoices, only: [:index]
-      resources :invoice_items, only: [:index]
-      resources :transactions, only: [:index]
+      resources :merchants, only: [:index, :show]
+      resources :customers, only: [:index, :show]
+      resources :items, only: [:index, :show]
+      resources :invoices, only: [:index, :show]
+      resources :invoice_items, only: [:index, :show]
+      resources :transactions, only: [:index, :show]
     end
   end
 end

--- a/spec/requests/api/v1/customers_request_spec.rb
+++ b/spec/requests/api/v1/customers_request_spec.rb
@@ -12,4 +12,18 @@ describe "Customers API" do
 
     expect(customers.count).to eq(3)
   end
+
+  it "can get one customer by its id" do
+    object = create(:customer)
+
+    get "/api/v1/customers/#{object.id}"
+
+    customer = JSON.parse(response.body)["data"]
+
+    expect(response).to be_successful
+    expect(customer["type"]).to eq("customer")
+    expect(customer["attributes"]["id"]).to eq(object.id)
+    expect(customer["attributes"]["first_name"]).to eq(object.first_name)
+    expect(customer["attributes"]["last_name"]).to eq(object.last_name)
+  end
 end

--- a/spec/requests/api/v1/invoice_items_request_spec.rb
+++ b/spec/requests/api/v1/invoice_items_request_spec.rb
@@ -12,4 +12,20 @@ describe "Invoice Items API" do
 
     expect(invoice_items.count).to eq(3)
   end
+
+  it "can get one invoice item by its id" do
+    object = create(:invoice_item)
+
+    get "/api/v1/invoice_items/#{object.id}"
+
+    invoice_item = JSON.parse(response.body)["data"]
+
+    expect(response).to be_successful
+    expect(invoice_item["type"]).to eq("invoice_item")
+    expect(invoice_item["attributes"]["id"]).to eq(object.id)
+    expect(invoice_item["attributes"]["item_id"]).to eq(object.item_id)
+    expect(invoice_item["attributes"]["invoice_id"]).to eq(object.invoice_id)
+    expect(invoice_item["attributes"]["quantity"]).to eq(object.quantity)
+    expect(invoice_item["attributes"]["unit_price"]).to eq(object.unit_price)
+  end
 end

--- a/spec/requests/api/v1/invoices_request_spec.rb
+++ b/spec/requests/api/v1/invoices_request_spec.rb
@@ -12,4 +12,19 @@ describe "Invoices API" do
 
     expect(invoices.count).to eq(3)
   end
+
+  it "can get one invoice by its id" do
+    object = create(:invoice)
+
+    get "/api/v1/invoices/#{object.id}"
+
+    invoice = JSON.parse(response.body)["data"]
+
+    expect(response).to be_successful
+    expect(invoice["type"]).to eq("invoice")
+    expect(invoice["attributes"]["id"]).to eq(object.id)
+    expect(invoice["attributes"]["customer_id"]).to eq(object.customer_id)
+    expect(invoice["attributes"]["merchant_id"]).to eq(object.merchant_id)
+    expect(invoice["attributes"]["status"]).to eq(object.status)
+  end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -12,4 +12,19 @@ describe "Items API" do
 
     expect(items.count).to eq(3)
   end
+
+  it "can get one item by its id" do
+    object = create(:item)
+
+    get "/api/v1/items/#{object.id}"
+
+    item = JSON.parse(response.body)["data"]
+
+    expect(response).to be_successful
+    expect(item["type"]).to eq("item")
+    expect(item["attributes"]["id"]).to eq(object.id)
+    expect(item["attributes"]["description"]).to eq(object.description)
+    expect(item["attributes"]["unit_price"]).to eq(object.unit_price)
+    expect(item["attributes"]["merchant_id"]).to eq(object.merchant_id)
+  end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -23,6 +23,7 @@ describe "Items API" do
     expect(response).to be_successful
     expect(item["type"]).to eq("item")
     expect(item["attributes"]["id"]).to eq(object.id)
+    expect(item["attributes"]["name"]).to eq(object.name)
     expect(item["attributes"]["description"]).to eq(object.description)
     expect(item["attributes"]["unit_price"]).to eq(object.unit_price)
     expect(item["attributes"]["merchant_id"]).to eq(object.merchant_id)

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -12,4 +12,17 @@ describe "Merchants API" do
 
     expect(merchants.count).to eq(3)
   end
+
+  it "can get one merchant by its id" do
+    object = create(:merchant)
+
+    get "/api/v1/merchants/#{object.id}"
+
+    merchant = JSON.parse(response.body)["data"]
+
+    expect(response).to be_successful
+    expect(merchant["type"]).to eq("merchant")
+    expect(merchant["attributes"]["id"]).to eq(object.id)
+    expect(merchant["attributes"]["name"]).to eq(object.name)
+  end
 end

--- a/spec/requests/api/v1/transactions_request_spec.rb
+++ b/spec/requests/api/v1/transactions_request_spec.rb
@@ -26,5 +26,7 @@ describe "Transactions API" do
     expect(transaction["attributes"]["invoice_id"]).to eq(object.invoice_id)
     expect(transaction["attributes"]["credit_card_number"]).to eq(object.credit_card_number)
     expect(transaction["attributes"]["result"]).to eq(object.result)
+
+    expect(transaction["attributes"]["credit_card_expiration_date"]).to eq(nil)
   end
 end

--- a/spec/requests/api/v1/transactions_request_spec.rb
+++ b/spec/requests/api/v1/transactions_request_spec.rb
@@ -12,4 +12,19 @@ describe "Transactions API" do
 
     expect(transactions.count).to eq(3)
   end
+
+  it "can get one transaction by its id" do
+    object = create(:transaction)
+
+    get "/api/v1/transactions/#{object.id}"
+
+    transaction = JSON.parse(response.body)["data"]
+
+    expect(response).to be_successful
+    expect(transaction["type"]).to eq("transaction")
+    expect(transaction["attributes"]["id"]).to eq(object.id)
+    expect(transaction["attributes"]["invoice_id"]).to eq(object.invoice_id)
+    expect(transaction["attributes"]["credit_card_number"]).to eq(object.credit_card_number)
+    expect(transaction["attributes"]["result"]).to eq(object.result)
+  end
 end


### PR DESCRIPTION
This PR brings in the functionality of getting a single, specific resource from our APIs. Each of our tables have a Show method in their Controller, that will return only the resource wanted by searching via ID. 
`get /api/v1/resources/1` will return JSON for the object with an ID of 1.
The specs ensure that each endpoint returns only the permitted information that is processed through the Serializer.