### PR TITLE
Unit Price and Credit Card Number hotfixes

### DIFF
--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,4 +1,8 @@
 class InvoiceItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :item_id, :invoice_id, :quantity, :unit_price
+  attributes :id, :item_id, :invoice_id, :quantity
+
+  attribute :unit_price do |object|
+    "#{object.unit_price.fdiv(100)}"
+  end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,4 +1,8 @@
 class ItemSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :id, :name, :description, :unit_price, :merchant_id
+  attributes :id, :name, :description, :merchant_id
+
+  attribute :unit_price do |object|
+    "#{object.unit_price.fdiv(100)}"
+  end
 end

--- a/db/migrate/20190625211520_create_transactions.rb
+++ b/db/migrate/20190625211520_create_transactions.rb
@@ -2,7 +2,7 @@ class CreateTransactions < ActiveRecord::Migration[5.1]
   def change
     create_table :transactions do |t|
       t.references :invoice, foreign_key: true
-      t.bigint :credit_card_number
+      t.string :credit_card_number
       t.string :credit_card_expiration_date
       t.string :result
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -61,7 +61,7 @@ ActiveRecord::Schema.define(version: 20190625211520) do
 
   create_table "transactions", force: :cascade do |t|
     t.bigint "invoice_id"
-    t.bigint "credit_card_number"
+    t.string "credit_card_number"
     t.string "credit_card_expiration_date"
     t.string "result"
     t.datetime "created_at", null: false

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :transaction do
     invoice
-    credit_card_number { 1234567890123456 }
+    credit_card_number { "1234567890123456" }
     credit_card_expiration_date { "12/34" }
     result { "success" }
   end

--- a/spec/requests/api/v1/invoice_items_request_spec.rb
+++ b/spec/requests/api/v1/invoice_items_request_spec.rb
@@ -26,6 +26,6 @@ describe "Invoice Items API" do
     expect(invoice_item["attributes"]["item_id"]).to eq(object.item_id)
     expect(invoice_item["attributes"]["invoice_id"]).to eq(object.invoice_id)
     expect(invoice_item["attributes"]["quantity"]).to eq(object.quantity)
-    expect(invoice_item["attributes"]["unit_price"]).to eq(object.unit_price)
+    expect(invoice_item["attributes"]["unit_price"]).to eq(object.unit_price.fdiv(100).to_s)
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -25,7 +25,7 @@ describe "Items API" do
     expect(item["attributes"]["id"]).to eq(object.id)
     expect(item["attributes"]["name"]).to eq(object.name)
     expect(item["attributes"]["description"]).to eq(object.description)
-    expect(item["attributes"]["unit_price"]).to eq(object.unit_price)
+    expect(item["attributes"]["unit_price"]).to eq(object.unit_price.fdiv(100).to_s)
     expect(item["attributes"]["merchant_id"]).to eq(object.merchant_id)
   end
 end


### PR DESCRIPTION
This PR has hotfixes for how Credit Card Numbers are stored on a Transaction, and how the Unit Price is displayed to the end user on Items and Invoice Items.
Credit Card numbers are now stored as `strings`, instead of `bigints`. This required changing the migration and the schema.
Unit Prices are now serialized and formatted as a dollar amount, with 2 decimal places to represent the cents. They are stored in the DB as an integer, representing the number of total cents. This required `.fdiv(100)`.