### PR TITLE
All Merchants Business Intelligence

### DIFF
--- a/app/controllers/api/v1/merchants/most_items_controller.rb
+++ b/app/controllers/api/v1/merchants/most_items_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::MostItemsController < ApplicationController
+  def index
+    render json: MerchantSerializer.new(Merchant.most_items(params["quantity"]))
+  end
+end

--- a/app/controllers/api/v1/merchants/most_revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/most_revenue_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::MostRevenueController < ApplicationController
+  def index
+    render json: MerchantSerializer.new(Merchant.most_revenue(params["quantity"]))
+  end
+end

--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Merchants::RevenueController < ApplicationController
+  def index
+    render json: MerchantSerializer.new(Merchant.revenue(params["date"]))
+  end
+end

--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::Merchants::RevenueController < ApplicationController
   def index
-    render json: MerchantSerializer.new(Merchant.revenue(params["date"]))
+    render json: RevenueSerializer.new(Merchant.revenue(params["date"]))
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,4 +1,12 @@
 class Merchant < ApplicationRecord
   has_many :items
   has_many :invoices
+
+  def self.most_revenue(amount)
+    Merchant.joins(invoices: :invoice_items)
+            .select("merchants.*, SUM (invoice_items.quantity * invoice_items.unit_price) AS revenue")
+            .group("merchants.id")
+            .order("revenue DESC")
+            .limit(amount)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -9,4 +9,13 @@ class Merchant < ApplicationRecord
     .order("revenue DESC")
     .limit(amount)
   end
+
+  def self.most_items(amount)
+    joins(invoices: [:invoice_items, :transactions])
+    .select("merchants.*, SUM (invoice_items.quantity) AS items_sold")
+    .merge(Transaction.successful)
+    .group("merchants.id")
+    .order("items_sold DESC")
+    .limit(amount)
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -3,8 +3,9 @@ class Merchant < ApplicationRecord
   has_many :invoices
 
   def self.most_revenue(amount)
-    joins(invoices: :invoice_items)
+    joins(invoices: [:invoice_items, :transactions])
     .select("merchants.*, SUM (invoice_items.quantity * invoice_items.unit_price) AS revenue")
+    .merge(Transaction.successful)
     .group("merchants.id")
     .order("revenue DESC")
     .limit(amount)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -2,7 +2,7 @@ class Merchant < ApplicationRecord
   has_many :items
   has_many :invoices
 
-  def self.most_revenue(amount)
+  def self.most_revenue(amount = nil)
     joins(invoices: [:invoice_items, :transactions])
     .select("merchants.*, SUM (invoice_items.quantity * invoice_items.unit_price) AS revenue")
     .merge(Transaction.successful)
@@ -11,7 +11,7 @@ class Merchant < ApplicationRecord
     .limit(amount)
   end
 
-  def self.most_items(amount)
+  def self.most_items(amount = nil)
     joins(invoices: [:invoice_items, :transactions])
     .select("merchants.*, SUM (invoice_items.quantity) AS items_sold")
     .merge(Transaction.successful)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -3,10 +3,10 @@ class Merchant < ApplicationRecord
   has_many :invoices
 
   def self.most_revenue(amount)
-    Merchant.joins(invoices: :invoice_items)
-            .select("merchants.*, SUM (invoice_items.quantity * invoice_items.unit_price) AS revenue")
-            .group("merchants.id")
-            .order("revenue DESC")
-            .limit(amount)
+    joins(invoices: :invoice_items)
+    .select("merchants.*, SUM (invoice_items.quantity * invoice_items.unit_price) AS revenue")
+    .group("merchants.id")
+    .order("revenue DESC")
+    .limit(amount)
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -19,4 +19,11 @@ class Merchant < ApplicationRecord
     .order("items_sold DESC")
     .limit(amount)
   end
+
+  def self.revenue(date = Date.today.to_s)
+    joins(invoices: [:invoice_items, :transactions])
+    .where("CAST (invoices.updated_at AS DATE) = '#{Date.parse(date)}'")
+    .merge(Transaction.successful)
+    .select("SUM (invoice_items.quantity * invoice_items.unit_price) AS total_revenue")
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -25,5 +25,6 @@ class Merchant < ApplicationRecord
     .where("CAST (invoices.updated_at AS DATE) = '#{Date.parse(date)}'")
     .merge(Transaction.successful)
     .select("SUM (invoice_items.quantity * invoice_items.unit_price) AS total_revenue")
+    .take
   end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,3 +1,5 @@
 class Transaction < ApplicationRecord
   belongs_to :invoice
+
+  scope :successful, -> { where result: "success"}
 end

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -3,6 +3,6 @@ class InvoiceItemSerializer
   attributes :id, :item_id, :invoice_id, :quantity
 
   attribute :unit_price do |object|
-    "#{object.unit_price.fdiv(100)}"
+    "#{('%.2f' % object.unit_price.fdiv(100))}"
   end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -3,6 +3,6 @@ class ItemSerializer
   attributes :id, :name, :description, :merchant_id
 
   attribute :unit_price do |object|
-    "#{object.unit_price.fdiv(100)}"
+    "#{'%.2f' % object.unit_price.fdiv(100)}"
   end
 end

--- a/app/serializers/revenue_serializer.rb
+++ b/app/serializers/revenue_serializer.rb
@@ -1,0 +1,10 @@
+class RevenueSerializer
+  include FastJsonapi::ObjectSerializer
+  attribute :total_revenue do |object|
+    if object.total_revenue.nil?
+      "0.00"
+    else
+      "#{'%.2f' % object.total_revenue.fdiv(100)}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
+      namespace :merchants do
+        get '/most_revenue', to: 'most_revenue#index'
+      end
       resources :merchants, only: [:index, :show]
       resources :customers, only: [:index, :show]
       resources :items, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       namespace :merchants do
         get '/most_revenue', to: 'most_revenue#index'
         get '/most_items', to: 'most_items#index'
+        get '/revenue', to: 'revenue#index'
       end
       resources :merchants, only: [:index, :show]
       resources :customers, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :merchants do
         get '/most_revenue', to: 'most_revenue#index'
+        get '/most_items', to: 'most_items#index'
       end
       resources :merchants, only: [:index, :show]
       resources :customers, only: [:index, :show]

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -5,4 +5,36 @@ RSpec.describe Merchant, type: :model do
     it { should have_many :items }
     it { should have_many :invoices }
   end
+
+  describe 'class methods' do
+    before :each do
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+      @merchant_3 = create(:merchant)
+      @customer_1 = create(:customer)
+      @customer_2 = create(:customer)
+      @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+      @item_2 = create(:item, unit_price: 1000, merchant: @merchant_2)
+      @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
+      @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
+      @invoice_item_1 = create(:invoice_item, quantity: 30, unit_price: 100, invoice: @invoice_1, item: @item_1)
+      @transaction_1 = create(:transaction, invoice: @invoice_1)
+      @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
+      @invoice_item_2 = create(:invoice_item, quantity: 20, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+      @transaction_2 = create(:transaction, invoice: @invoice_2)
+      @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
+      @invoice_item_3 = create(:invoice_item, quantity: 21, unit_price: 200, invoice: @invoice_3, item: @item_3)
+      @transaction_3 = create(:transaction, invoice: @invoice_3)
+    end
+
+    it 'most_revenue' do
+      expect(Merchant.most_revenue(1)).to eq([@merchant_2])
+      expect(Merchant.most_revenue).to eq([@merchant_2, @merchant_3, @merchant_1])
+    end
+
+    it 'most_items' do
+      expect(Merchant.most_items(1)).to eq([@merchant_1])
+      expect(Merchant.most_items).to eq([@merchant_1, @merchant_3, @merchant_2])
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Merchant, type: :model do
       @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
       @item_2 = create(:item, unit_price: 1000, merchant: @merchant_2)
       @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
-      @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
+      @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1, updated_at: "2012-04-01 09:53:09 UTC")
       @invoice_item_1 = create(:invoice_item, quantity: 30, unit_price: 100, invoice: @invoice_1, item: @item_1)
       @transaction_1 = create(:transaction, invoice: @invoice_1)
-      @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
+      @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2, updated_at: "2012-04-01 09:54:09 UTC")
       @invoice_item_2 = create(:invoice_item, quantity: 20, unit_price: 1000, invoice: @invoice_2, item: @item_2)
       @transaction_2 = create(:transaction, invoice: @invoice_2)
-      @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
+      @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2, updated_at: "2012-04-02 09:54:09 UTC")
       @invoice_item_3 = create(:invoice_item, quantity: 21, unit_price: 200, invoice: @invoice_3, item: @item_3)
       @transaction_3 = create(:transaction, invoice: @invoice_3)
     end
@@ -35,6 +35,11 @@ RSpec.describe Merchant, type: :model do
     it 'most_items' do
       expect(Merchant.most_items(1)).to eq([@merchant_1])
       expect(Merchant.most_items).to eq([@merchant_1, @merchant_3, @merchant_2])
+    end
+
+    it 'revenue' do
+      expect(Merchant.revenue("2012-04-01")).to eq(23000)
+      expect(Merchant.revenue("2012-04-02")).to eq(4200)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -40,6 +40,15 @@ RSpec.describe Merchant, type: :model do
     it 'revenue' do
       expect(Merchant.revenue("2012-04-01")[0]["total_revenue"]).to eq(23000)
       expect(Merchant.revenue("2012-04-02")[0]["total_revenue"]).to eq(4200)
+
+      merchant_4 = create(:merchant)
+      customer_4 = create(:customer)
+      item_4 = create(:item, unit_price: 100, merchant: merchant_4)
+      invoice_4 = create(:invoice, merchant: merchant_4, customer: customer_4)
+      invoice_item_4 = create(:invoice_item, quantity: 15, unit_price: 100, invoice: invoice_4, item: item_4)
+      transaction_4 = create(:transaction, invoice: invoice_4)
+
+      expect(Merchant.revenue[0]["total_revenue"]).to eq(1500)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe Merchant, type: :model do
     end
 
     it 'revenue' do
-      expect(Merchant.revenue("2012-04-01")).to eq(23000)
-      expect(Merchant.revenue("2012-04-02")).to eq(4200)
+      expect(Merchant.revenue("2012-04-01")[0]["total_revenue"]).to eq(23000)
+      expect(Merchant.revenue("2012-04-02")[0]["total_revenue"]).to eq(4200)
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -38,17 +38,17 @@ RSpec.describe Merchant, type: :model do
     end
 
     it 'revenue' do
-      expect(Merchant.revenue("2012-04-01")[0]["total_revenue"]).to eq(23000)
-      expect(Merchant.revenue("2012-04-02")[0]["total_revenue"]).to eq(4200)
+      expect(Merchant.revenue("2012-04-01")["total_revenue"]).to eq(23000)
+      expect(Merchant.revenue("2012-04-02")["total_revenue"]).to eq(4200)
 
       merchant_4 = create(:merchant)
       customer_4 = create(:customer)
       item_4 = create(:item, unit_price: 100, merchant: merchant_4)
-      invoice_4 = create(:invoice, merchant: merchant_4, customer: customer_4)
+      invoice_4 = create(:invoice, merchant: merchant_4, customer: customer_4, updated_at: Date.today)
       invoice_item_4 = create(:invoice_item, quantity: 15, unit_price: 100, invoice: invoice_4, item: item_4)
       transaction_4 = create(:transaction, invoice: invoice_4)
 
-      expect(Merchant.revenue[0]["total_revenue"]).to eq(1500)
+      expect(Merchant.revenue["total_revenue"]).to eq(1500)
     end
   end
 end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -4,4 +4,30 @@ RSpec.describe Transaction, type: :model do
   describe 'relationships' do
     it { should belong_to :invoice}
   end
+
+  describe 'scopes' do
+    before :each do
+      @merchant_1 = create(:merchant)
+      @merchant_2 = create(:merchant)
+      @merchant_3 = create(:merchant)
+      @customer_1 = create(:customer)
+      @customer_2 = create(:customer)
+      @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+      @item_2 = create(:item, unit_price: 1000, merchant: @merchant_2)
+      @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
+      @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
+      @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+      @transaction_1 = create(:transaction, invoice: @invoice_1)
+      @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
+      @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+      @transaction_2 = create(:transaction, invoice: @invoice_2)
+      @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
+      @invoice_item_3 = create(:invoice_item, quantity: 1, unit_price: 200, invoice: @invoice_3, item: @item_3)
+      @transaction_3 = create(:transaction, invoice: @invoice_3, result: "failed")
+    end
+
+    it 'successful' do
+      expect(Transaction.successful).to eq([@transaction_1, @transaction_2])
+    end
+  end
 end

--- a/spec/requests/api/v1/invoice_items_request_spec.rb
+++ b/spec/requests/api/v1/invoice_items_request_spec.rb
@@ -14,7 +14,7 @@ describe "Invoice Items API" do
   end
 
   it "can get one invoice item by its id" do
-    object = create(:invoice_item)
+    object = create(:invoice_item, unit_price: 1000)
 
     get "/api/v1/invoice_items/#{object.id}"
 
@@ -26,6 +26,6 @@ describe "Invoice Items API" do
     expect(invoice_item["attributes"]["item_id"]).to eq(object.item_id)
     expect(invoice_item["attributes"]["invoice_id"]).to eq(object.invoice_id)
     expect(invoice_item["attributes"]["quantity"]).to eq(object.quantity)
-    expect(invoice_item["attributes"]["unit_price"]).to eq(object.unit_price.fdiv(100).to_s)
+    expect(invoice_item["attributes"]["unit_price"]).to eq(('%.2f' % object.unit_price.fdiv(100)).to_s)
   end
 end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -14,7 +14,7 @@ describe "Items API" do
   end
 
   it "can get one item by its id" do
-    object = create(:item)
+    object = create(:item, unit_price: 1000)
 
     get "/api/v1/items/#{object.id}"
 
@@ -25,7 +25,7 @@ describe "Items API" do
     expect(item["attributes"]["id"]).to eq(object.id)
     expect(item["attributes"]["name"]).to eq(object.name)
     expect(item["attributes"]["description"]).to eq(object.description)
-    expect(item["attributes"]["unit_price"]).to eq(object.unit_price.fdiv(100).to_s)
+    expect(item["attributes"]["unit_price"]).to eq(('%.2f' % object.unit_price.fdiv(100)).to_s)
     expect(item["attributes"]["merchant_id"]).to eq(object.merchant_id)
   end
 end

--- a/spec/requests/api/v1/merchants/most_items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/most_items_request_spec.rb
@@ -12,10 +12,13 @@ describe 'Merchants Most Items API' do
     @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
     @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
     @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @transaction_1 = create(:transaction, invoice: @invoice_1)
     @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
     @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @transaction_2 = create(:transaction, invoice: @invoice_2)
     @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
     @invoice_item_3 = create(:invoice_item, quantity: 10, unit_price: 200, invoice: @invoice_3, item: @item_3)
+    @transaction_3 = create(:transaction, invoice: @invoice_3)
   end
 
   it 'sends a list of merchants by most items sold' do

--- a/spec/requests/api/v1/merchants/most_items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/most_items_request_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+describe 'Merchants Most Items API' do
+  before :each do
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @merchant_3 = create(:merchant)
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+    @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+    @item_2 = create(:item, unit_price: 1000, merchant: @merchant_2)
+    @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
+    @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
+    @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
+    @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
+    @invoice_item_3 = create(:invoice_item, quantity: 10, unit_price: 200, invoice: @invoice_3, item: @item_3)
+  end
+
+  it 'sends a list of merchants by most items sold' do
+    merchant_list = [@merchant_3, @merchant_1, @merchant_2]
+    get '/api/v1/merchants/most_items'
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)['data']
+
+    expect(merchants.count).to eq(3)
+
+    merchants.each_with_index do |merchant, index|
+      expect(merchant["type"]).to eq("merchant")
+      expect(merchant["attributes"]["id"]).to eq(merchant_list[index].id)
+      expect(merchant["attributes"]["name"]).to eq(merchant_list[index].name)
+    end
+  end
+
+  it 'sends the top merchant by most items' do
+    get '/api/v1/merchants/most_items?quantity=1'
+
+    expect(response).to be_successful
+
+    merchant = JSON.parse(response.body)["data"]
+
+    expect(merchant.count).to eq(1)
+    expect(merchant[0]["type"]).to eq("merchant")
+    expect(merchant[0]["attributes"]["id"]).to eq(@merchant_3.id)
+    expect(merchant[0]["attributes"]["name"]).to eq(@merchant_3.name)
+  end
+end

--- a/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
+++ b/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
@@ -19,7 +19,6 @@ describe 'Merchants Most Revenue API' do
   end
 
   it 'sends the top merchant by most revenue' do
-
     get '/api/v1/merchants/most_revenue?quantity=1'
 
     expect(response).to be_successful
@@ -30,5 +29,22 @@ describe 'Merchants Most Revenue API' do
     expect(merchant[0]["type"]).to eq("merchant")
     expect(merchant[0]["attributes"]["id"]).to eq(@merchant_2.id)
     expect(merchant[0]["attributes"]["name"]).to eq(@merchant_2.name)
+  end
+
+  it 'sends the top merchants by most revenue' do
+    merchant_list = [@merchant_2, @merchant_1, @merchant_3]
+    get '/api/v1/merchants/most_revenue'
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants.count).to eq(3)
+
+    merchants.each_with_index do |merchant, index|
+      expect(merchant["type"]).to eq("merchant")
+      expect(merchant["attributes"]["id"]).to eq(merchant_list[index].id)
+      expect(merchant["attributes"]["name"]).to eq(merchant_list[index].name)
+    end
   end
 end

--- a/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
+++ b/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
@@ -20,15 +20,15 @@ describe 'Merchants Most Revenue API' do
 
   it 'sends the top merchant by most revenue' do
 
-    get '/api/v1/merchants/most_revenue'
+    get '/api/v1/merchants/most_revenue?quantity=1'
 
     expect(response).to be_successful
 
     merchant = JSON.parse(response.body)["data"]
 
     expect(merchant.count).to eq(1)
-    expect(merchant["type"]).to eq("merchant")
-    expect(merchant["attributes"]["id"]).to eq(@merchant_2.id)
-    expect(merchant["attributes"]["name"]).to eq(@merchant_2.name)
+    expect(merchant[0]["type"]).to eq("merchant")
+    expect(merchant[0]["attributes"]["id"]).to eq(@merchant_2.id)
+    expect(merchant[0]["attributes"]["name"]).to eq(@merchant_2.name)
   end
 end

--- a/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
+++ b/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
@@ -12,10 +12,13 @@ describe 'Merchants Most Revenue API' do
     @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
     @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
     @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @transaction_1 = create(:transaction, invoice: @invoice_1)
     @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
     @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @transaction_2 = create(:transaction, invoice: @invoice_2)
     @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
     @invoice_item_3 = create(:invoice_item, quantity: 1, unit_price: 200, invoice: @invoice_3, item: @item_3)
+    @transaction_3 = create(:transaction, invoice: @invoice_3)
   end
 
   it 'sends the top merchant by most revenue' do

--- a/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
+++ b/spec/requests/api/v1/merchants/most_revenue_request_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'Merchants Most Revenue API' do
+  before :each do
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @merchant_3 = create(:merchant)
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+    @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+    @item_2 = create(:item, unit_price: 1000, merchant: @merchant_2)
+    @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
+    @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1)
+    @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2)
+    @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2)
+    @invoice_item_3 = create(:invoice_item, quantity: 1, unit_price: 200, invoice: @invoice_3, item: @item_3)
+  end
+
+  it 'sends the top merchant by most revenue' do
+
+    get '/api/v1/merchants/most_revenue'
+
+    expect(response).to be_successful
+
+    merchant = JSON.parse(response.body)["data"]
+
+    expect(merchant.count).to eq(1)
+    expect(merchant["type"]).to eq("merchant")
+    expect(merchant["attributes"]["id"]).to eq(@merchant_2.id)
+    expect(merchant["attributes"]["name"]).to eq(@merchant_2.name)
+  end
+end

--- a/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
+++ b/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
@@ -43,9 +43,9 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)["data"]
+    merchants = JSON.parse(response.body)["data"][0]
 
-    expect(merchants["total_revenue"]).to eq("33.00")
+    expect(merchants["attributes"]["total_revenue"]).to eq("33.00")
   end
 
   it 'sends value of revenue for 2012-03-12' do
@@ -53,9 +53,9 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)["data"]
+    merchants = JSON.parse(response.body)["data"][0]
 
-    expect(merchants["total_revenue"]).to eq("14.00")
+    expect(merchants["attributes"]["total_revenue"]).to eq("14.00")
   end
 
   it 'sends value of revenue for 2012-03-26' do
@@ -63,9 +63,9 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchant = JSON.parse(response.body)["data"]
+    merchant = JSON.parse(response.body)["data"][0]
 
-    expect(merchant["total_revenue"]).to eq("4.00")
+    expect(merchant["attributes"]["total_revenue"]).to eq("4.00")
   end
 
   it 'sends value of no revenue for 2012-04-01' do
@@ -73,8 +73,8 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)["data"]
+    merchants = JSON.parse(response.body)["data"][0]
 
-    expect(merchants["total_revenue"]).to eq("0")
+    expect(merchants["attributes"]["total_revenue"]).to eq("0.00")
   end
 end

--- a/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
+++ b/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
@@ -43,7 +43,7 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)["data"][0]
+    merchants = JSON.parse(response.body)["data"]
 
     expect(merchants["attributes"]["total_revenue"]).to eq("33.00")
   end
@@ -53,7 +53,7 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)["data"][0]
+    merchants = JSON.parse(response.body)["data"]
 
     expect(merchants["attributes"]["total_revenue"]).to eq("14.00")
   end
@@ -63,7 +63,7 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchant = JSON.parse(response.body)["data"][0]
+    merchant = JSON.parse(response.body)["data"]
 
     expect(merchant["attributes"]["total_revenue"]).to eq("4.00")
   end
@@ -73,7 +73,7 @@ describe 'Merchants Revenue by Date API' do
 
     expect(response).to be_successful
 
-    merchants = JSON.parse(response.body)["data"][0]
+    merchants = JSON.parse(response.body)["data"]
 
     expect(merchants["attributes"]["total_revenue"]).to eq("0.00")
   end

--- a/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
+++ b/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe 'Merchants Revenue by Date API' do
+  before :each do
+    @merchant_1 = create(:merchant)
+    @merchant_2 = create(:merchant)
+    @merchant_3 = create(:merchant)
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+    @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+    @item_2 = create(:item, unit_price: 1000, merchant: @merchant_2)
+    @item_3 = create(:item, unit_price: 200, merchant: @merchant_3)
+    @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @transaction_1 = create(:transaction, invoice: @invoice_1)
+    @invoice_2 = create(:invoice, merchant: @merchant_2, customer: @customer_2, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @transaction_2 = create(:transaction, invoice: @invoice_2)
+    @invoice_3 = create(:invoice, merchant: @merchant_3, customer: @customer_2, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_3 = create(:invoice_item, quantity: 1, unit_price: 200, invoice: @invoice_3, item: @item_3)
+    @transaction_3 = create(:transaction, invoice: @invoice_3)
+    @merchant_4 = create(:merchant)
+    @merchant_5 = create(:merchant)
+    @merchant_6 = create(:merchant)
+    @customer_3 = create(:customer)
+    @customer_4 = create(:customer)
+    @item_4 = create(:item, unit_price: 100, merchant: @merchant_4)
+    @item_5 = create(:item, unit_price: 1000, merchant: @merchant_5)
+    @item_6 = create(:item, unit_price: 200, merchant: @merchant_6)
+    @invoice_4 = create(:invoice, merchant: @merchant_4, customer: @customer_3, updated_at: "2012-03-26 09:54:09 UTC")
+    @invoice_item_4 = create(:invoice_item, quantity: 4, unit_price: 100, invoice: @invoice_4, item: @item_4)
+    @transaction_4 = create(:transaction, invoice: @invoice_4)
+    @invoice_5 = create(:invoice, merchant: @merchant_5, customer: @customer_4, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_5 = create(:invoice_item, quantity: 1, unit_price: 1000, invoice: @invoice_5, item: @item_5)
+    @transaction_2 = create(:transaction, invoice: @invoice_5)
+    @invoice_6 = create(:invoice, merchant: @merchant_6, customer: @customer_4, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_6 = create(:invoice_item, quantity: 6, unit_price: 200, invoice: @invoice_6, item: @item_6)
+    @transaction_6 = create(:transaction, invoice: @invoice_6)
+  end
+
+  it 'sends value of revenue for 2012-03-25' do
+    get "/api/v1/merchants/revenue?date='2012-03-25'"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["total_revenue"]).to eq("33.00")
+  end
+
+  it 'sends value of revenue for 2012-03-12' do
+    get "/api/v1/merchants/revenue?date='2012-03-12'"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["total_revenue"]).to eq("14.00")
+  end
+
+  it 'sends value of revenue for 2012-03-26' do
+    get "/api/v1/merchants/revenue?date='2012-03-26'"
+
+    expect(response).to be_successful
+
+    merchant = JSON.parse(response.body)["data"]
+
+    expect(merchant["total_revenue"]).to eq("4.00")
+  end
+
+  it 'sends value of no revenue for 2012-04-01' do
+    get "/api/v1/merchants/revenue?date='2012-04-01'"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["total_revenue"]).to eq("0")
+  end
+end


### PR DESCRIPTION
This PR brings in the functionality of 3 new endpoints providing business logic. These endpoints are for information from the Merchants table, taking into account all of the merchants in our system.

- Most Revenue
- - This endpoint will take a parameter of `quantity` and return a list of Merchants, limited by the quantity and then sorted by Most to Least revenue. With no parameter, it will return all Merchants.
- Most Items
- - This endpoint will take a parameter of `quantity` and return a list of Merchants, limited by the quantity and then sorted by Most to Least items. With no parameter, it will return all Merchants.
- Revenue
- - This endpoint will take a parameter of `date` and return a __dollar__ value of all invoices from day. With no parameter, it will return the value for invoices for _today_.
- - This endpoint required a new Serializer, since the output of Total Revenue did not correspond to any existing resources in our database. While we may be calling the method on the Merchant table, the JSON output should not contain any other Merchant information other than Total Revenue.

This PR also brings in the scope for Transactions of `successful` to filter them for their result = 'success'. We use this in all of the above endpoints to ensure that our results are only based on Invoices that are completed. 
The formatting of Unit Prices on Items and Invoice Items was also another concern handled in the process of creating these endpoints. In the situation where a price/revenue (in cents) ends in 0, the output would render as `10.0` instead of `10.00` like it should have. We added a round to the second decimal to resolve this, which also carried over to the Revenue endpoint output.