### PR TITLE
Single Merchant Business Intelligence

### DIFF
--- a/app/controllers/api/v1/merchants/favorite_customer_controller.rb
+++ b/app/controllers/api/v1/merchants/favorite_customer_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Merchants::FavoriteCustomerController < ApplicationController
+  def show
+    merchant = Merchant.find(params[:id])
+    render json: CustomerSerializer.new(merchant.favorite_customer)
+  end
+end

--- a/app/controllers/api/v1/merchants/revenue_controller.rb
+++ b/app/controllers/api/v1/merchants/revenue_controller.rb
@@ -1,5 +1,10 @@
 class Api::V1::Merchants::RevenueController < ApplicationController
   def index
-    render json: RevenueSerializer.new(Merchant.revenue(params["date"]))
+    render json: TotalRevenueSerializer.new(Merchant.revenue(params["date"]))
+  end
+
+  def show
+    merchant = Merchant.find(params[:id])
+    render json: RevenueSerializer.new(merchant.revenue(params["date"]))
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -40,4 +40,14 @@ class Merchant < ApplicationRecord
 
     total_revenue.take
   end
+
+  def favorite_customer
+    Customer.joins(invoices: [:transactions, :merchant])
+    .merge(Transaction.successful)
+    .where("invoices.merchant_id = #{self.id}")
+    .select("customers.*, COUNT (invoices.id) AS invoice_count")
+    .group(:id)
+    .order("invoice_count DESC")
+    .limit(1).take
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -20,11 +20,24 @@ class Merchant < ApplicationRecord
     .limit(amount)
   end
 
-  def self.revenue(date = Date.today.to_s)
+  def self.revenue(date = nil)
+    date = Date.today.to_s if date == nil
     joins(invoices: [:invoice_items, :transactions])
     .where("CAST (invoices.updated_at AS DATE) = '#{Date.parse(date)}'")
     .merge(Transaction.successful)
     .select("SUM (invoice_items.quantity * invoice_items.unit_price) AS total_revenue")
     .take
+  end
+
+  def revenue(date = nil)
+    total_revenue = invoices.joins(:invoice_items, :transactions)
+    .merge(Transaction.successful)
+    .select("SUM (invoice_items.quantity * invoice_items.unit_price) AS revenue")
+
+    if date != nil
+      total_revenue = total_revenue.where("CAST (invoices.updated_at AS DATE) = '#{Date.parse(date)}'")
+    end
+
+    total_revenue.take
   end
 end

--- a/app/serializers/revenue_serializer.rb
+++ b/app/serializers/revenue_serializer.rb
@@ -1,10 +1,10 @@
 class RevenueSerializer
   include FastJsonapi::ObjectSerializer
-  attribute :total_revenue do |object|
-    if object.total_revenue.nil?
+  attribute :revenue do |object|
+    if object.revenue.nil?
       "0.00"
     else
-      "#{'%.2f' % object.total_revenue.fdiv(100)}"
+      "#{'%.2f' % object.revenue.fdiv(100)}"
     end
   end
 end

--- a/app/serializers/total_revenue_serializer.rb
+++ b/app/serializers/total_revenue_serializer.rb
@@ -1,0 +1,10 @@
+class TotalRevenueSerializer
+  include FastJsonapi::ObjectSerializer
+  attribute :total_revenue do |object|
+    if object.total_revenue.nil?
+      "0.00"
+    else
+      "#{'%.2f' % object.total_revenue.fdiv(100)}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
         get '/most_items', to: 'most_items#index'
         get '/revenue', to: 'revenue#index'
         get '/:id/revenue', to: 'revenue#show'
+        get '/:id/favorite_customer', to: 'favorite_customer#show'
       end
       resources :merchants, only: [:index, :show]
       resources :customers, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
         get '/most_revenue', to: 'most_revenue#index'
         get '/most_items', to: 'most_items#index'
         get '/revenue', to: 'revenue#index'
+        get '/:id/revenue', to: 'revenue#show'
       end
       resources :merchants, only: [:index, :show]
       resources :customers, only: [:index, :show]

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -51,4 +51,37 @@ RSpec.describe Merchant, type: :model do
       expect(Merchant.revenue["total_revenue"]).to eq(1500)
     end
   end
+
+  describe 'instance methods' do
+    before :each do
+      @merchant_1 = create(:merchant)
+      @customer_1 = create(:customer)
+      @customer_2 = create(:customer)
+      @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+      @item_2 = create(:item, unit_price: 1000, merchant: @merchant_1)
+      @item_3 = create(:item, unit_price: 200, merchant: @merchant_1)
+      @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1, updated_at: "2012-04-01 09:53:09 UTC")
+      @invoice_item_1 = create(:invoice_item, quantity: 30, unit_price: 100, invoice: @invoice_1, item: @item_1)
+      @transaction_1 = create(:transaction, invoice: @invoice_1)
+      @invoice_2 = create(:invoice, merchant: @merchant_1, customer: @customer_2, updated_at: "2012-04-01 09:54:09 UTC")
+      @invoice_item_2 = create(:invoice_item, quantity: 20, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+      @transaction_2 = create(:transaction, invoice: @invoice_2)
+      @invoice_3 = create(:invoice, merchant: @merchant_1, customer: @customer_2, updated_at: "2012-04-02 09:54:09 UTC")
+      @invoice_item_3 = create(:invoice_item, quantity: 21, unit_price: 200, invoice: @invoice_3, item: @item_3)
+      @transaction_3 = create(:transaction, invoice: @invoice_3)
+    end
+
+    it 'revenue' do
+      expect(@merchant_1.revenue("2012-04-01")["revenue"]).to eq(23000)
+      expect(@merchant_1.revenue("2012-04-02")["revenue"]).to eq(4200)
+
+      customer_4 = create(:customer)
+      item_4 = create(:item, unit_price: 100, merchant: @merchant_1)
+      invoice_4 = create(:invoice, merchant: @merchant_1, customer: customer_4, updated_at: Date.today)
+      invoice_item_4 = create(:invoice_item, quantity: 15, unit_price: 100, invoice: invoice_4, item: item_4)
+      transaction_4 = create(:transaction, invoice: invoice_4)
+
+      expect(@merchant_1.revenue["revenue"]).to eq(28700)
+    end
+  end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -54,34 +54,56 @@ RSpec.describe Merchant, type: :model do
 
   describe 'instance methods' do
     before :each do
-      @merchant_1 = create(:merchant)
+      @merchant = create(:merchant)
       @customer_1 = create(:customer)
       @customer_2 = create(:customer)
-      @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
-      @item_2 = create(:item, unit_price: 1000, merchant: @merchant_1)
-      @item_3 = create(:item, unit_price: 200, merchant: @merchant_1)
-      @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1, updated_at: "2012-04-01 09:53:09 UTC")
+      @item_1 = create(:item, unit_price: 100, merchant: @merchant)
+      @item_2 = create(:item, unit_price: 1000, merchant: @merchant)
+      @item_3 = create(:item, unit_price: 200, merchant: @merchant)
+      @invoice_1 = create(:invoice, merchant: @merchant, customer: @customer_1, updated_at: "2012-04-01 09:53:09 UTC")
       @invoice_item_1 = create(:invoice_item, quantity: 30, unit_price: 100, invoice: @invoice_1, item: @item_1)
       @transaction_1 = create(:transaction, invoice: @invoice_1)
-      @invoice_2 = create(:invoice, merchant: @merchant_1, customer: @customer_2, updated_at: "2012-04-01 09:54:09 UTC")
+      @invoice_2 = create(:invoice, merchant: @merchant, customer: @customer_2, updated_at: "2012-04-01 09:54:09 UTC")
       @invoice_item_2 = create(:invoice_item, quantity: 20, unit_price: 1000, invoice: @invoice_2, item: @item_2)
       @transaction_2 = create(:transaction, invoice: @invoice_2)
-      @invoice_3 = create(:invoice, merchant: @merchant_1, customer: @customer_2, updated_at: "2012-04-02 09:54:09 UTC")
+      @invoice_3 = create(:invoice, merchant: @merchant, customer: @customer_2, updated_at: "2012-04-02 09:54:09 UTC")
       @invoice_item_3 = create(:invoice_item, quantity: 21, unit_price: 200, invoice: @invoice_3, item: @item_3)
       @transaction_3 = create(:transaction, invoice: @invoice_3)
     end
 
     it 'revenue' do
-      expect(@merchant_1.revenue("2012-04-01")["revenue"]).to eq(23000)
-      expect(@merchant_1.revenue("2012-04-02")["revenue"]).to eq(4200)
+      expect(@merchant.revenue("2012-04-01")["revenue"]).to eq(23000)
+      expect(@merchant.revenue("2012-04-02")["revenue"]).to eq(4200)
 
       customer_4 = create(:customer)
-      item_4 = create(:item, unit_price: 100, merchant: @merchant_1)
-      invoice_4 = create(:invoice, merchant: @merchant_1, customer: customer_4, updated_at: Date.today)
+      item_4 = create(:item, unit_price: 100, merchant: @merchant)
+      invoice_4 = create(:invoice, merchant: @merchant, customer: customer_4, updated_at: Date.today)
       invoice_item_4 = create(:invoice_item, quantity: 15, unit_price: 100, invoice: invoice_4, item: item_4)
       transaction_4 = create(:transaction, invoice: invoice_4)
 
-      expect(@merchant_1.revenue["revenue"]).to eq(28700)
+      expect(@merchant.revenue["revenue"]).to eq(28700)
+    end
+
+    it 'favorite_customer' do
+      expect(@merchant.favorite_customer).to eq(@customer_2)
+
+      invoice_4 = create(:invoice, merchant: @merchant, customer: @customer_1, updated_at: "2012-04-01 09:53:09 UTC")
+      invoice_item_1 = create(:invoice_item, quantity: 30, unit_price: 100, invoice: invoice_4, item: @item_1)
+      transaction_4 = create(:transaction, invoice: invoice_4)
+      invoice_5 = create(:invoice, merchant: @merchant, customer: @customer_1, updated_at: "2012-04-01 09:53:09 UTC")
+      invoice_item_1 = create(:invoice_item, quantity: 30, unit_price: 100, invoice: invoice_5, item: @item_1)
+      transaction_5 = create(:transaction, invoice: invoice_5)
+
+      expect(@merchant.favorite_customer).to eq(@customer_1)
+
+      invoice_6 = create(:invoice, merchant: @merchant, customer: @customer_2, updated_at: "2012-04-02 09:54:09 UTC")
+      invoice_item_3 = create(:invoice_item, quantity: 21, unit_price: 200, invoice: invoice_6, item: @item_3)
+      transaction_6 = create(:transaction, invoice: invoice_6, result: "failed")
+      invoice_7 = create(:invoice, merchant: @merchant, customer: @customer_2, updated_at: "2012-04-02 09:54:09 UTC")
+      invoice_item_3 = create(:invoice_item, quantity: 21, unit_price: 200, invoice: invoice_7, item: @item_3)
+      transaction_7 = create(:transaction, invoice: invoice_7, result: "failed")
+
+      expect(@merchant.favorite_customer).to eq(@customer_1)
     end
   end
 end

--- a/spec/requests/api/v1/merchants/favorite_customer_request_spec.rb
+++ b/spec/requests/api/v1/merchants/favorite_customer_request_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+describe 'Merchants Favorite Customer API' do
+  before :each do
+    @merchant = create(:merchant)
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+    @customer_3 = create(:customer)
+    @customer_4 = create(:customer)
+    @customer_5 = create(:customer)
+    @customer_6 = create(:customer)
+    @item_1 = create(:item, unit_price: 100, merchant: @merchant)
+    @item_2 = create(:item, unit_price: 1000, merchant: @merchant)
+    @item_3 = create(:item, unit_price: 200, merchant: @merchant)
+    @item_4 = create(:item, unit_price: 500, merchant: @merchant)
+    @item_5 = create(:item, unit_price: 2000, merchant: @merchant)
+    @item_6 = create(:item, unit_price: 20, merchant: @merchant)
+
+    @invoice_1 = create(:invoice, merchant: @merchant, customer: @customer_1, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @transaction_1 = create(:transaction, invoice: @invoice_1)
+
+    @invoice_2 = create(:invoice, merchant: @merchant, customer: @customer_2, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @transaction_2 = create(:transaction, invoice: @invoice_2)
+
+    @invoice_3 = create(:invoice, merchant: @merchant, customer: @customer_3, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_3 = create(:invoice_item, quantity: 1, unit_price: 200, invoice: @invoice_3, item: @item_3)
+    @transaction_3 = create(:transaction, invoice: @invoice_3)
+
+    @invoice_4 = create(:invoice, merchant: @merchant, customer: @customer_4, updated_at: "2012-03-26 09:54:09 UTC")
+    @invoice_item_4 = create(:invoice_item, quantity: 4, unit_price: 100, invoice: @invoice_4, item: @item_4)
+    @transaction_4 = create(:transaction, invoice: @invoice_4)
+
+    @invoice_5 = create(:invoice, merchant: @merchant, customer: @customer_5, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_5 = create(:invoice_item, quantity: 1, unit_price: 1000, invoice: @invoice_5, item: @item_5)
+    @transaction_2 = create(:transaction, invoice: @invoice_5)
+
+    @invoice_6 = create(:invoice, merchant: @merchant, customer: @customer_6, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_6 = create(:invoice_item, quantity: 6, unit_price: 200, invoice: @invoice_6, item: @item_6)
+    @transaction_6 = create(:transaction, invoice: @invoice_6)
+
+    @invoice_7 = create(:invoice, merchant: @merchant, customer: @customer_6, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_6 = create(:invoice_item, quantity: 6, unit_price: 200, invoice: @invoice_7, item: @item_6)
+    @transaction_6 = create(:transaction, invoice: @invoice_7)
+
+    @invoice_8 = create(:invoice, merchant: @merchant, customer: @customer_6, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_6 = create(:invoice_item, quantity: 6, unit_price: 200, invoice: @invoice_8, item: @item_6)
+    @transaction_6 = create(:transaction, invoice: @invoice_8)
+
+    @invoice_9 = create(:invoice, merchant: @merchant, customer: @customer_5, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_6 = create(:invoice_item, quantity: 6, unit_price: 200, invoice: @invoice_9, item: @item_6)
+    @transaction_6 = create(:transaction, invoice: @invoice_9)
+  end
+
+  it 'sends the top customer based on number of successful transactions' do
+
+    get "/api/v1/merchants/#{@merchant.id}/favorite_customer"
+
+    expect(response).to be_successful
+
+    customer = JSON.parse(response.body)['data']
+
+    expect(customer.count).to eq(1)
+
+    expect(customer["attributes"]["id"]).to eq(@customer_6.id)
+  end
+end

--- a/spec/requests/api/v1/merchants/favorite_customer_request_spec.rb
+++ b/spec/requests/api/v1/merchants/favorite_customer_request_spec.rb
@@ -61,7 +61,7 @@ describe 'Merchants Favorite Customer API' do
 
     customer = JSON.parse(response.body)['data']
 
-    expect(customer.count).to eq(1)
+    expect(customer["type"]).to eq("customer")
 
     expect(customer["attributes"]["id"]).to eq(@customer_6.id)
   end

--- a/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
+++ b/spec/requests/api/v1/merchants/revenue_by_date_request_spec.rb
@@ -77,4 +77,21 @@ describe 'Merchants Revenue by Date API' do
 
     expect(merchants["attributes"]["total_revenue"]).to eq("0.00")
   end
+
+  it 'sends value for todays revenue with no specific date' do
+    merchant_4 = create(:merchant)
+    customer_4 = create(:customer)
+    item_4 = create(:item, unit_price: 100, merchant: merchant_4)
+    invoice_4 = create(:invoice, merchant: merchant_4, customer: customer_4, updated_at: Date.today)
+    invoice_item_4 = create(:invoice_item, quantity: 15, unit_price: 100, invoice: invoice_4, item: item_4)
+    transaction_4 = create(:transaction, invoice: invoice_4)
+
+    get "/api/v1/merchants/revenue"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["attributes"]["total_revenue"]).to eq("15.00")
+  end
 end

--- a/spec/requests/api/v1/merchants/single_merchant_revenue_by_date_request_spec.rb
+++ b/spec/requests/api/v1/merchants/single_merchant_revenue_by_date_request_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+describe 'Single Merchant Revenue by Date API' do
+  before :each do
+    @merchant_1 = create(:merchant)
+    @customer_1 = create(:customer)
+    @customer_2 = create(:customer)
+    @item_1 = create(:item, unit_price: 100, merchant: @merchant_1)
+    @item_2 = create(:item, unit_price: 1000, merchant: @merchant_1)
+    @item_3 = create(:item, unit_price: 200, merchant: @merchant_1)
+    @invoice_1 = create(:invoice, merchant: @merchant_1, customer: @customer_1, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_1 = create(:invoice_item, quantity: 3, unit_price: 100, invoice: @invoice_1, item: @item_1)
+    @transaction_1 = create(:transaction, invoice: @invoice_1)
+    @invoice_2 = create(:invoice, merchant: @merchant_1, customer: @customer_2, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_2 = create(:invoice_item, quantity: 2, unit_price: 1000, invoice: @invoice_2, item: @item_2)
+    @transaction_2 = create(:transaction, invoice: @invoice_2)
+    @invoice_3 = create(:invoice, merchant: @merchant_1, customer: @customer_2, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_3 = create(:invoice_item, quantity: 1, unit_price: 200, invoice: @invoice_3, item: @item_3)
+    @transaction_3 = create(:transaction, invoice: @invoice_3)
+    @customer_3 = create(:customer)
+    @customer_4 = create(:customer)
+    @item_4 = create(:item, unit_price: 100, merchant: @merchant_1)
+    @item_5 = create(:item, unit_price: 1000, merchant: @merchant_1)
+    @item_6 = create(:item, unit_price: 200, merchant: @merchant_1)
+    @invoice_4 = create(:invoice, merchant: @merchant_1, customer: @customer_3, updated_at: "2012-03-26 09:54:09 UTC")
+    @invoice_item_4 = create(:invoice_item, quantity: 4, unit_price: 100, invoice: @invoice_4, item: @item_4)
+    @transaction_4 = create(:transaction, invoice: @invoice_4)
+    @invoice_5 = create(:invoice, merchant: @merchant_1, customer: @customer_4, updated_at: "2012-03-25 09:54:09 UTC")
+    @invoice_item_5 = create(:invoice_item, quantity: 1, unit_price: 1000, invoice: @invoice_5, item: @item_5)
+    @transaction_2 = create(:transaction, invoice: @invoice_5)
+    @invoice_6 = create(:invoice, merchant: @merchant_1, customer: @customer_4, updated_at: "2012-03-12 05:54:09 UTC")
+    @invoice_item_6 = create(:invoice_item, quantity: 6, unit_price: 200, invoice: @invoice_6, item: @item_6)
+    @transaction_6 = create(:transaction, invoice: @invoice_6)
+  end
+
+  it 'sends value of revenue for 2012-03-25' do
+    get "/api/v1/merchants/#{@merchant_1.id}/revenue?date='2012-03-25'"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["attributes"]["revenue"]).to eq("33.00")
+  end
+
+  it 'sends value of revenue for 2012-03-12' do
+    get "/api/v1/merchants/#{@merchant_1.id}/revenue?date='2012-03-12'"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["attributes"]["revenue"]).to eq("14.00")
+  end
+
+  it 'sends value of revenue for 2012-03-26' do
+    get "/api/v1/merchants/#{@merchant_1.id}/revenue?date='2012-03-26'"
+
+    expect(response).to be_successful
+
+    merchant = JSON.parse(response.body)["data"]
+
+    expect(merchant["attributes"]["revenue"]).to eq("4.00")
+  end
+
+  it 'sends value of no revenue for 2012-04-01' do
+    get "/api/v1/merchants/#{@merchant_1.id}/revenue?date='2012-04-01'"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["attributes"]["revenue"]).to eq("0.00")
+  end
+
+  it 'sends value of all revenue for merchant when sending no date' do
+    get "/api/v1/merchants/#{@merchant_1.id}/revenue"
+
+    expect(response).to be_successful
+
+    merchants = JSON.parse(response.body)["data"]
+
+    expect(merchants["attributes"]["revenue"]).to eq("51.00")
+  end
+end


### PR DESCRIPTION
This PR brings in the business logic endpoints when looking at a Single Merchant. This requires that the user includes a specific ID in the path of the request.

- Revenue
- - This endpoint will take a parameter of date and return a __dollar__ value of all invoices from day. With no parameter, it will return the value for __all__ dates.
- - - This is different behavior than the other Merchants Revenue endpoint, which has already been noted and will be adjusted on the All Merchants endpoint accordingly.
- - Since the All Merchants Revenue endpoint returns the value of `total revenue`, and this endpoint returns `revenue`, the Serializers needed to be shifted around. The TotalRevenueSerializer is used for the All Merchants endpoint, and the RevenueSerializer is used for the Single Merchant endpoint.

- Favorite Customer
- - This endpoint takes no parameters and returns the Customer that has the highest number of completed Invoices with the Single Merchant you are looking at. 