### PR TITLE
Transaction Relationship Endpoint

### DIFF
--- a/app/controllers/api/v1/transactions/invoice_controller.rb
+++ b/app/controllers/api/v1/transactions/invoice_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Transactions::InvoiceController < ApplicationController
+  def index
+    render json: InvoiceSerializer.new(Invoice.joins(:transactions).where(transactions: {id: params[:id]}).take)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,8 @@ Rails.application.routes.draw do
       namespace :transactions do
         get '/find', to: 'find#show'
         get '/find_all', to: 'find#index'
+
+        get '/:id/invoice', to: 'invoice#index'
       end
       resources :merchants, only: [:index, :show]
       resources :customers, only: [:index, :show]

--- a/spec/requests/api/v1/transactions/invoice_relationship_request_spec.rb
+++ b/spec/requests/api/v1/transactions/invoice_relationship_request_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'Transaction Invoice Relationship API' do
+  before :each do
+    @merchant = create(:merchant)
+    @customer = create(:customer)
+    @invoice = create(:invoice, customer: @customer, merchant: @merchant, status: "fraudulent")
+    @transaction = create(:transaction, invoice: @invoice)
+  end
+
+  it 'sends the invoice of a transaction' do
+    get "/api/v1/transactions/#{@transaction.id}/invoice"
+    expect(response).to be_successful
+
+    invoice = JSON.parse(response.body)['data']
+
+    expect(invoice["type"]).to eq("invoice")
+    expect(invoice["attributes"]["id"]).to eq(@invoice.id)
+    expect(invoice["attributes"]["customer_id"]).to eq(@invoice.customer_id)
+    expect(invoice["attributes"]["merchant_id"]).to eq(@invoice.merchant_id)
+    expect(invoice["attributes"]["status"]).to eq(@invoice.status)
+  end
+end


### PR DESCRIPTION
This PR brings in the singular related resource endpoint for Transactions. The request path requires the ID of the Transaction, and then /invoice.

- Invoice
- - This returns the single Invoice that the Transaction belongs to, and any of its relevant information.